### PR TITLE
Add Sprint 3 Meeting Minutes

### DIFF
--- a/Meeting Minutes/Sprint3_meeting10_ Nov9.md
+++ b/Meeting Minutes/Sprint3_meeting10_ Nov9.md
@@ -1,0 +1,34 @@
+## Date: November 9, 2024
+
+### Attendees:
+- Hala Belamri (self-meeting)
+
+### Agenda:
+1. Sprint 3 progress review
+2. Decision on feature focus and adjustments for Sprint 4
+
+### Discussion:
+- **Feature Implementation**:
+  - **Dimensional Assessment**: Implemented a four-dimensional assessment feature.
+  - **Results Display**:
+    - Enabled access to display results.
+    - Added options to download results as CSV or PDF.
+    - Decided to postpone the feature for instructors to modify questions and dimensions to Sprint 4 due to time constraints.
+  - **CSS Overhaul**: Updated the styling for a more refined look.
+  - **Student Team Features**:
+    - Created logic to recognize signed-in users and their associated teams.
+    - Implemented a new feature allowing students to:
+      - Request to leave their current team.
+      - Request to join a different team, with requests visible to the instructor.
+    - Updated assessment logic so students no longer need to manually enter their name or select a team; their group and email are automatically recognized.
+  - **Contact Us Page**: Added a message box to enable users to send messages.
+  - **LinkedIn Link**: Added a LinkedIn link on the Contact Us page.
+
+- **Testing and Pipeline Adjustments**:
+  - Adjusted and implemented two new tests to accommodate recent changes.
+  - Fixed existing tests due to modifications in logic.
+  - Updated CI pipeline to reflect file structure changes and ensured successful runs.
+
+### Action Items:
+- Focus on adding more tests and further CSS styling adjustments.
+- Prioritize feature refinements and testing for the remainder of Sprint 3.

--- a/Meeting Minutes/Sprint3_meeting9_Nov7,md
+++ b/Meeting Minutes/Sprint3_meeting9_Nov7,md
@@ -1,0 +1,26 @@
+# Meeting Minutes
+
+## Date: November 7, 2024
+
+### Attendees:
+- Hala Belamri
+- New TA (assessing individual work)
+
+### Agenda:
+1. Demo of current project progress
+2. Feedback on issue naming and project adjustments
+
+### Discussion:
+- **Project Demo**: Showcased the progress of the project, including the new and old GitHub repositories.
+- **Feedback from TA**:
+  - Issue Naming: TA suggested naming issues for user stories as "US" and acceptance tests as "AT" to align with Agile methodology.
+  - If an issue is not a user story, it should be labeled accordingly with an appropriate identifier.
+- **Project Adjustments**:
+  - Agreed to add several new features and adjustments:
+    - Displaying assessment results for instructors.
+    - Potentially adding functionalities to allow instructors to change questions and dimensions if time permits.
+
+### Action Items:
+- Rename issues and tests in the repository to match the suggested naming conventions.
+- Plan additional features and adjustments to be implemented in upcoming sprints.
+- Submit new links for Sprint3.


### PR DESCRIPTION
# Pull Request: Add Sprint 3 Meeting Minutes

## Linked Issue:
This pull request addresses **Issue #21** - [US3-9: Add Sprint 3 Meeting Minutes](#21).

## Summary:
This pull request includes the meeting minutes for Sprint 3, specifically from the sessions held on November 7 and November 9. These minutes document the discussions, feedback, and actions decided upon during this sprint.

## Changes:
- Added meeting minutes in Markdown format for:
  - **November 7, 2024**: Discussion with the new TA covering feedback on issue naming conventions, planned adjustments, and new feature ideas.
  - **November 9, 2024**: Self-review of Sprint 3 progress, including newly implemented features, adjustments to the CI pipeline, and a refined testing approach.

## Details:
- Each meeting entry includes:
  - **Attendees**
  - **Agenda**
  - **Discussion Points**
  - **Action Items**

## Checklist:
- [x] Meeting minutes formatted and reviewed.
- [x] Added documentation aligns with Agile standards.
- [x] CI pipeline checks passed.

### Notes:
Postponed the instructor modification feature for questions and dimensions to Sprint 4 due to time constraints. Upcoming tasks include expanding tests and completing additional styling refinements.
